### PR TITLE
Allow empty array to be used as a params in get requests.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change log
 
+## master (unreleased)
+* [#34](https://github.com/ONLYOFFICE/onlyoffice_api_gem/pull/34): Allow empty array to be used as param in get requests.
+
 ## 0.6
 ### New features
 * Support of keepConvertStatus for insert methods (from OnlyOffice > 8.9.1)

--- a/lib/teamlab/request.rb
+++ b/lib/teamlab/request.rb
@@ -44,7 +44,7 @@ module Teamlab
       rescue Exception => e
         raise e
       end
-      fail "Error #{response.code}: #{response.error}" unless response.success
+      raise "Error #{response.code}: #{response.error}" unless response.success
       response
     end
 
@@ -56,6 +56,7 @@ module Teamlab
       command = args.first.instance_of?(Array) ? '/' + args.shift.join('/') : args.shift.to_s
       opts = {}
       opts[:body] = args.last.instance_of?(Hash) ? args.pop : {}
+      remove_empty_array(opts, type)
       opts[:headers] = Teamlab.config.headers
       if opts[:body].key?(:somefile)
         opts[:query] = opts.delete(:body)
@@ -63,6 +64,11 @@ module Teamlab
       end
       opts[:query] = opts.delete(:body) if type == :get
       [command, opts]
+    end
+
+    def remove_empty_array(opts, type)
+      return if type == :get
+      opts[:body].delete_if { |_key, value| value == [] }
     end
   end
 end


### PR DESCRIPTION
Error 500 if empty array used as a params in post/put requests.
https://github.com/jnunemaker/httparty/pull/477