### PR TITLE
Fix generate_err_msg, html now can be handled as api response

### DIFF
--- a/lib/teamlab/response.rb
+++ b/lib/teamlab/response.rb
@@ -21,7 +21,13 @@ module Teamlab
       "#{http_response.request.http_method} #{http_response.request.path}\nbody: "\
       "#{JSON.pretty_generate(http_response.request.options[:body])}"\
       "\n\nresponse:\n"\
-      "#{JSON.pretty_generate(http_response.parsed_response)}"
+      "#{prettify_response(http_response.parsed_response)}"
+    end
+
+    def prettify_response(msg)
+      JSON.pretty_generate(msg)
+    rescue Encoding::UndefinedConversionError
+      msg.force_encoding(Encoding::UTF_8)
     end
   end
 end


### PR DESCRIPTION
fix errors like: "\xEF" from ASCII-8BIT to UTF-8