### PR TITLE
Force usage of httparty 0.15

### DIFF
--- a/onlyoffice_api.gemspec
+++ b/onlyoffice_api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'httparty', '~> 0.13'
+  spec.add_runtime_dependency 'httparty', '~> 0.15.7'
   spec.add_runtime_dependency 'activesupport', '~> 4'
   spec.add_runtime_dependency 'rspec', '~> 3.3'
   spec.add_runtime_dependency 'httmultiparty', '~> 0.3.16'


### PR DESCRIPTION
Since version 0.16 compability with `httmultiparty` broken.
Need to remove usage of `httmultiparty` in future versions.