### PR TITLE
Remove non-existing crm group methods

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 * `Crm#create_opportunity` set requred argument `bidCurrencyAbbr`
+* Remove non-existing method `Crm#group_contact_info`, `Crm#group_contact_info_update`
 
 ## 0.6
 ### New features

--- a/lib/teamlab/modules/crm.rb
+++ b/lib/teamlab/modules/crm.rb
@@ -480,10 +480,6 @@ module Teamlab
       @request.get(['contact', contact_id.to_s, 'data', info_type.to_s])
     end
 
-    def group_contact_info(*items)
-      @request.post(%w[contact data], items: items.flatten)
-    end
-
     def quick_person_list_creation(data)
       @request.post(%w[contact person quick], data: data)
     end
@@ -516,10 +512,6 @@ module Teamlab
       @request.put(%w[contact], contactids: contact_ids.flatten)
     end
     alias delete_contacts_bulk delete_contact_group
-
-    def group_contact_info_update(*items)
-      @request.put(%w[contact data], items: items.flatten)
-    end
 
     def merge_contacts(from_contact_id, to_contact_id)
       @request.put(%w[contact merge], fromcontactid: from_contact_id, tocontactid: to_contact_id)

--- a/spec/lib/crm_spec.rb
+++ b/spec/lib/crm_spec.rb
@@ -854,14 +854,6 @@ describe '[CRM]' do
     end
   end
 
-  describe '#group_contact_info' do
-    it_should_behave_like 'an api request' do
-      pending 'http://bugzserver/show_bug.cgi?id=23988'
-      let(:command) { :group_contact_info }
-      let(:args) { [[random_id(:new_contact), CONTACT_INFO_TYPES.sample]] }
-    end
-  end
-
   describe '#quick_company_list_creation' do
     it_should_behave_like 'an api request' do
       let(:command) { :quick_company_list_creation }
@@ -877,14 +869,6 @@ describe '[CRM]' do
       let(:add_data_to_collector) { true }
       let(:data_param) { :contact_address_ids }
       let(:param_names) { %w[] }
-    end
-  end
-
-  describe '#group_contact_info_update' do
-    it_should_behave_like 'an api request' do
-      pending 'http://bugzserver/show_bug.cgi?id=23988'
-      let(:command) { :group_contact_info_update }
-      let(:args) { [[random_id(:new_contact), CONTACT_INFO_TYPES.sample]] }
     end
   end
 


### PR DESCRIPTION
Not working according to:
https://bugzilla.onlyoffice.com/show_bug.cgi?id=23988