### PR TITLE
Fix `Crm#get_summary_table` request

### DIFF
--- a/lib/teamlab/modules/crm.rb
+++ b/lib/teamlab/modules/crm.rb
@@ -34,7 +34,7 @@ module Teamlab
     end
 
     def get_summary_table(currency)
-      @request.get(['settings', 'currency', currency.to_s, 'summarytable'])
+      @request.get(%w[settings currency summarytable], currency: currency)
     end
 
     def create_opportunity(stage_id, title, responsible_id, options = {})

--- a/spec/lib/crm_spec.rb
+++ b/spec/lib/crm_spec.rb
@@ -371,9 +371,8 @@ describe '[CRM]' do
 
   describe '#get_summary_table' do
     it_should_behave_like 'an api request' do
-      pending 'http://bugzserver/show_bug.cgi?id=23883'
       let(:command) { :get_summary_table }
-      let(:args) { [random_word] }
+      let(:args) { [CURRENCY.sample] }
     end
   end
 


### PR DESCRIPTION
Currency should send as param
According to:
https://api.onlyoffice.com/portals/method/crm/get/api/2.0/crm/settings/currency/summarytable
Also see:
https://bugzilla.onlyoffice.com/show_bug.cgi?id=23883