### PR TITLE
Fix `Crm#create_invoice_line` request

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 * `Crm#create_opportunity` set requred argument `bidCurrencyAbbr`
 * Remove non-existing method `Crm#group_contact_info`, `Crm#group_contact_info_update`
 * Fix `Crm#get_summary_table` request
+* Fix `Crm#create_invoice_line` request
 * Fix `Settings#get_sso_settings` request
 * Fix `Community#update_wiki_page_comment` request
 * Fix `Files#create_html_in_common_docs` request

--- a/lib/teamlab/modules/crm.rb
+++ b/lib/teamlab/modules/crm.rb
@@ -170,8 +170,8 @@ module Teamlab
                                    invoiceLines: invoice_line }.merge(options))
     end
 
-    def create_invoice_line(invoice_id, options = {})
-      @request.post(%w[invoiceline], { invoiceId: invoice_id }.merge(options))
+    def create_invoice_line(invoice_id, invoice_item_id, options = {})
+      @request.post(%w[invoiceline], { invoiceId: invoice_id, invoiceItemId: invoice_item_id }.merge(options))
     end
 
     def create_invoice_item(title, description, price, stock_keeping_unit, options = {})

--- a/spec/lib/crm_spec.rb
+++ b/spec/lib/crm_spec.rb
@@ -100,7 +100,7 @@ describe '[CRM]' do
   describe '#create_invoice_line' do
     it_should_behave_like 'an api request' do
       let(:command) { :create_invoice_line }
-      let(:args) { [random_id(:invoice)] }
+      let(:args) { [random_id(:invoice), random_id(:invoice_item)] }
       let(:add_data_to_collector) { true }
       let(:data_param) { :invoice_line_ids }
       let(:param_names) { %w[id] }


### PR DESCRIPTION
According to:
https://api.onlyoffice.com/portals/method/crm/post/api/2.0/crm/invoiceline
`invoiceItemId` is required