### PR TITLE
Fix warning about using `URI.escape`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -61,6 +61,7 @@
 * Remove non-documented `Projects#get_simple_task_by_filter`
 * Remove non-documented `Projects#get_task_order`
 * Remove non-documented `Projects#get_tasks_by_ids`
+* Fix warning about using `URI.escape`
 
 ### Refactor
 

--- a/lib/teamlab/request.rb
+++ b/lib/teamlab/request.rb
@@ -33,7 +33,7 @@ module Teamlab
 
     def request(type, args)
       command, opts = parse_args(args, type)
-      url = URI.encode(generate_request_url(command))
+      url = generate_request_url(command)
       attempts = 0
       begin
         response = Teamlab::Response.new(HTTParty.send(type, url, opts))


### PR DESCRIPTION
This warning shown in ruby > 2.7

`URI.escape` was introduced in https://github.com/ONLYOFFICE/onlyoffice_api_gem/pull/26
But I cannot find any real usage of this
Fixing in theory, without real case is pretty hard.
So this change can broke some case (and after found out case it'll be fixed)
Or maybe stay unnoticed.