### PR TITLE
Fix `Community#get_bookmarks_by_tag` for tag with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Fix travis command to running markdownlint
+* Fix `Community#get_bookmarks_by_tag` for tag with spaces
 
 ## 0.7.0 (2020-04-29)
 

--- a/lib/teamlab/modules/community/community_bookmarks.rb
+++ b/lib/teamlab/modules/community/community_bookmarks.rb
@@ -28,7 +28,7 @@ module Teamlab
     end
 
     def get_bookmarks_by_tag(tag)
-      @request.get(['bookmark', 'tag', tag.to_s])
+      @request.get(['bookmark', 'tag', tag.to_s.gsub(' ', '%20')])
     end
 
     def get_recently_added_bookmarks

--- a/spec/lib/community/functional/community_bookmarks_functional_spec.rb
+++ b/spec/lib/community/functional/community_bookmarks_functional_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe '[Community][Functional] Bookmarks' do
+  let(:tag) { "tag with space #{SecureRandom.uuid}" }
+
+  it 'Get bookmark by tag with spaces in tag' do
+    added = Teamlab.community.add_bookmark('www.google.com',
+                                           'description',
+                                           tags: tag).body['response']
+    expect(Teamlab.community.get_bookmarks_by_tag(tag)
+                  .body['response'].first['id']).to eq(added['id'])
+  end
+end


### PR DESCRIPTION
Any kind of escapes, unless `URI.escape` (which is deprecated)
is incorrect.
So I'll just replace just space symbol