### PR TITLE
Fix running markdownlint in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
-language: ruby
-rvm:
-  - 2.5
-
-script:
-  - npm install -g markdownlint-cli
-  - markdownlint *.md
-  - rake
+matrix:
+  include:
+    - name: markdown lint
+      language: node_js
+      node_js: "12"
+      install:
+        - npm install -g markdownlint-cli
+      script:
+        - markdownlint *.md
+    - name: ruby tests
+      language: ruby
+      rvm:
+        - 2.5
+      script: rake
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Fix travis command to running markdownlint
+
 ## 0.7.0 (2020-04-29)
 
 ### New features


### PR DESCRIPTION
By default travis uses nodejs 8
markdownlint-cli do not support it, see:
https://github.com/igorshubovych/markdownlint-cli/issues/90