### PR TITLE
Fix `Community#get_bookmarks_by_tag` for CommunityServer v11.0

### DIFF
--- a/lib/teamlab/modules/community/community_bookmarks.rb
+++ b/lib/teamlab/modules/community/community_bookmarks.rb
@@ -28,7 +28,7 @@ module Teamlab
     end
 
     def get_bookmarks_by_tag(tag)
-      @request.get(['bookmark', 'tag', tag.to_s.gsub(' ', '%20')])
+      @request.get(['bookmark', "bytag?tag=#{tag.to_s.gsub(' ', '%20')}"])
     end
 
     def get_recently_added_bookmarks


### PR DESCRIPTION
Since v11.0 there is new correct request to get tags
See this bug for more details:
https://bugzilla.onlyoffice.com/show_bug.cgi?id=45538

Docs:
https://api.onlyoffice.com/portals/method/community/get/api/2.0/community/bookmark/bytag