### PR TITLE
Revert "Add `ruby-3.0` and `ruby-head` to CI"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,15 +3,6 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow-failures }}
-    strategy:
-      matrix:
-        ruby: [ 2.7, 3.0 ]
-        allow-failures: [ false ]
-        include:
-          - ruby: head
-            allow-failures: true
-      max-parallel: 1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
   `MailServer#delete_mailbox` method
 * Add `Mail#operations` method
 * Add `rubocop-rake` support
-* Add `ruby-3.0` and `ruby-head` to CI
 
 ### Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,4 +95,4 @@ DEPENDENCIES
   yard (>= 0.9.20)
 
 BUNDLED WITH
-   2.2.11
+   2.1.4


### PR DESCRIPTION
Reverts ONLYOFFICE/onlyoffice_api_gem#238

Random failure of test made almost impossible to perform 3 test suites one after another

Better to leave only one currently. until all random failures are resolved