### PR TITLE
Enable tests for SSO and LDAP

### DIFF
--- a/spec/lib/settings_spec.rb
+++ b/spec/lib/settings_spec.rb
@@ -23,15 +23,13 @@ describe '[Settings]' do
   end
 
   describe '#get_sso_settings' do
-    it_behaves_like 'an api request', :pending do
-      pending 'only for self-hosted, error 500 when running on saas portal'
+    it_behaves_like 'an api request' do
       let(:command) { :get_sso_settings }
     end
   end
 
   describe '#get_ldap_settings' do
-    it_behaves_like 'an api request', :pending do
-      pending 'only for self-hosted, error 500 when running on saas portal'
+    it_behaves_like 'an api request' do
       let(:command) { :get_ldap_settings }
     end
   end


### PR DESCRIPTION
Since release of portals v11.5 on .com
those features are available for paid users