### PR TITLE
Replace 3 shared example tests with 1

### DIFF
--- a/lib/teamlab/response.rb
+++ b/lib/teamlab/response.rb
@@ -40,6 +40,10 @@ module Teamlab
       @body['response']
     end
 
+    def self.response_is_correct?(response)
+      response.success && response.error.nil? && response.body.is_a?(Hash)
+    end
+
     private
 
     # Sometime in strange situation, like maybe nginx errors

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,16 +55,8 @@ shared_examples_for 'an api request' do |*flags|
       expect(RequestHelper.current_responce).to be_instance_of(Teamlab::Response)
     end
 
-    it 'returns Teamlab::Response object with successful parameter, set to true' do
-      expect(RequestHelper.current_responce.success).to be_truthy
-    end
-
-    it 'returns Teamlab::Response object with nil error parameter' do
-      expect(RequestHelper.current_responce.error).to be_nil
-    end
-
-    it 'returns Teamlab::Response object with hash body' do
-      expect(RequestHelper.current_responce.body).to be_instance_of(Hash)
+    it 'returns Teamlab::Response object with successful parameter, nil error and hash body' do
+      expect(Teamlab::Response).to be_response_is_correct(RequestHelper.current_responce)
     end
   end
 


### PR DESCRIPTION
Check that response is succeeded, has no errors and return hash  in one test